### PR TITLE
fix(*): remove whitespace before first argument

### DIFF
--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/spoon/ImportAwareSniperPrinter.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/spoon/ImportAwareSniperPrinter.java
@@ -2,8 +2,6 @@
 package xyz.keksdose.spoon.code_solver.spoon;
 
 import spoon.compiler.Environment;
-import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtLambda;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtImport;
 import spoon.support.sniper.SniperJavaPrettyPrinter;

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/AssertionsTransformation.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/AssertionsTransformation.java
@@ -8,9 +8,10 @@ import spoon.experimental.CtUnresolvedImport;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtReference;
@@ -62,7 +63,7 @@ public class AssertionsTransformation extends TransformationProcessor<CtMethod<?
 			if (parameters.size() == 3) {
 				if (parameters.get(0).getType().getSimpleName().equals("String")) {
 					List<CtExpression<?>> newParameters = new ArrayList<>();
-					newParameters.add(parameters.get(1));
+					newParameters.add(parameters.get(1).clone());
 					newParameters.add(parameters.get(2));
 					newParameters.add(parameters.get(0));
 					junit4Assert.setArguments(newParameters);
@@ -71,7 +72,7 @@ public class AssertionsTransformation extends TransformationProcessor<CtMethod<?
 			if (parameters.size() == 2 && junit4Assert.getExecutable().getSimpleName().equals("assertTrue")) {
 				if (parameters.get(0).getType().getSimpleName().equals("String")) {
 					List<CtExpression<?>> newParameters = new ArrayList<>();
-					newParameters.add(parameters.get(1));
+					newParameters.add(parameters.get(1).clone());
 					newParameters.add(parameters.get(0));
 					junit4Assert.setArguments(newParameters);
 				}

--- a/code-transformation/src/test/java/xyz/keksdose/spoon/code_solver/JunitTests.java
+++ b/code-transformation/src/test/java/xyz/keksdose/spoon/code_solver/JunitTests.java
@@ -59,13 +59,33 @@ class JunitTests {
 		String resourcePath = "projects/bugs/AnnotationValuesTest.java";
 		File copy = TestHelper.createCopy(tempRoot, resourcePath, fileName);
 		List<TransformationCreator> transformations = createProcessorSupplier(v -> new TestAnnotation(v),
-			v -> new AssertionsTransformation(v));
+				v -> new AssertionsTransformation(v));
 		new TransformationHelper.Builder().path(tempRoot.getAbsolutePath())
 				.className("AnnotationValuesTest")
 				.processors(transformations)
 				.apply();
 		String result = Files.readString(copy.toPath());
 		assertThat(result).contains("@Test");
+		assertThat(result).contains("import org.junit.jupiter.api.Test;");
+		assertThat(result).doesNotContain("import org.junit.Test;");
+		assertThat(result).doesNotContain("import org.junit.Assert.");
+	}
+
+	@Test
+	public void printerDoesNotIncludeWhiteSpaceInInvocations(@TempDir File tempRoot) throws IOException {
+		String fileName = "WhiteSpaces.java";
+		String resourcePath = "projects/bugs/WhiteSpaces.java";
+		File copy = TestHelper.createCopy(tempRoot, resourcePath, fileName);
+		List<TransformationCreator> transformations = createProcessorSupplier(v -> new TestAnnotation(v),
+				v -> new AssertionsTransformation(v));
+		new TransformationHelper.Builder().path(tempRoot.getAbsolutePath())
+				.className("WhiteSpaces")
+				.processors(transformations)
+				.apply();
+		String result = Files.readString(copy.toPath());
+		assertThat(result).contains("@Test");
+		// no whitespace should be printed for the first argument.
+		assertThat(result).doesNotContain(" 1");
 		assertThat(result).contains("import org.junit.jupiter.api.Test;");
 		assertThat(result).doesNotContain("import org.junit.Test;");
 		assertThat(result).doesNotContain("import org.junit.Assert.");

--- a/code-transformation/src/test/resources/projects/bugs/WhiteSpaces.java
+++ b/code-transformation/src/test/resources/projects/bugs/WhiteSpaces.java
@@ -1,0 +1,13 @@
+package projects.bugs;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class WhiteSpaces {
+
+  @Test
+  public void testCase() {
+    assertEquals("Check the number of if in method", 1, 2);
+  }
+}


### PR DESCRIPTION
Reording arguments keeps the formatting. But the first argument shall never have a leading whitespace.
Cloning an element removes the known source fragment.