### PR TITLE
feat: add the concept of markdown changelogs

### DIFF
--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/config/ConfigStore.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/config/ConfigStore.java
@@ -45,4 +45,11 @@ public class ConfigStore {
 		return property.getProperty("git.branch_prefix");
 	}
 
+	public boolean getPrintMarkdown() {
+		return Boolean.valueOf(property.getProperty("changelog.markdown"));
+	}
+
+	public String getMarkdownChangeLogFile() {
+		return property.getProperty("changelog.markdown.file");
+	}
 }

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/history/Change.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/history/Change.java
@@ -5,17 +5,23 @@ import spoon.reflect.declaration.CtType;
 
 public class Change {
 
-	private String text;
+	private MarkdownString text;
 	private String issue;
 	private CtType<?> affectedType;
 
 	public Change(String text, String issue, CtType<?> affectedType) {
+		this.text = MarkdownString.fromRaw(text);
+		this.issue = issue;
+		this.affectedType = affectedType;
+	}
+
+	public Change(MarkdownString text, String issue, CtType<?> affectedType) {
 		this.text = text;
 		this.issue = issue;
 		this.affectedType = affectedType;
 	}
 
-	public String getText() {
+	public MarkdownString getChangeText() {
 		return text;
 	}
 

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/history/Changelog.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/history/Changelog.java
@@ -28,7 +28,7 @@ public class Changelog {
 		StringBuilder builder = new StringBuilder();
 		builder.append("The following has changed in the code:\n");
 		for (Change change : changes) {
-			builder.append(change.getText() + "\n");
+			builder.append(change.getChangeText() + "\n");
 		}
 		return builder.toString();
 	}

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/history/MarkdownString.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/history/MarkdownString.java
@@ -1,0 +1,59 @@
+
+package xyz.keksdose.spoon.code_solver.history;
+
+/**
+ * This class wrappes a string with it's markdown formatted value.
+ * Use this class to create markdown formatted strings.
+ * {@link asString()} returns the raw string.
+ * {@link asMarkdown()} returns the markdown formatted string.
+ */
+public class MarkdownString {
+
+	private String text;
+	private String markdownText;
+
+	private MarkdownString(String text) {
+		this.text = text;
+		this.markdownText = text;
+	}
+
+	private MarkdownString(String text, String markdownText) {
+		this.text = text;
+		this.markdownText = markdownText;
+	}
+
+	/**
+	 * Creates an instance from the given text. The markdown text is the same as the text.
+	 * @param value the text
+	 * @return  the instance
+	 */
+	public static MarkdownString fromRaw(String value) {
+		return new MarkdownString(value);
+	}
+
+	/**
+	 * Creates an instance from the given text and markdown text. 
+	 * @param value  the text
+	 * @param markdown  the text with markdown formattings
+	 * @return  the instance
+	 */
+	public static MarkdownString fromMarkdown(String value, String markdown) {
+		return new MarkdownString(value, markdown);
+	}
+
+	/**
+	 * Returns the text.
+	 * @return  the text
+	 */
+	public String asText() {
+		return text;
+	}
+
+	/**
+	 * Returns the markdown text.
+	 * @return  the markdown text
+	 */
+	public String asMarkdown() {
+		return markdownText;
+	}
+}

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/AssertThatTransformation.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/AssertThatTransformation.java
@@ -31,8 +31,8 @@ public class AssertThatTransformation extends TransformationProcessor<CtInvocati
 	private void notifyChangeListener(CtInvocation<?> invocation) {
 		CtType<?> parentType = invocation.getParent(CtType.class);
 		setChanged(parentType,
-			new Change(String.format("Replaced Assert.assertThat with MatcherAssert.assertThat in %s",
-				invocation.getParent(CtExecutable.class).getSignature()), "assertThat", parentType));
+			new Change(String.format("Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `%s`",
+				invocation.getParent(CtExecutable.class).getSimpleName()), "assertThat", parentType));
 	}
 
 	private void adjustImports(CtInvocation<?> invocation) {

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/AssertionsTransformation.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/AssertionsTransformation.java
@@ -22,6 +22,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.util.ModelList;
 import xyz.keksdose.spoon.code_solver.history.Change;
 import xyz.keksdose.spoon.code_solver.history.ChangeListener;
+import xyz.keksdose.spoon.code_solver.history.MarkdownString;
 import xyz.keksdose.spoon.code_solver.transformations.TransformationProcessor;
 
 public class AssertionsTransformation extends TransformationProcessor<CtMethod<?>> {
@@ -50,8 +51,10 @@ public class AssertionsTransformation extends TransformationProcessor<CtMethod<?
 		setChanged(declaringType, new Change(createChangeHistory(method), TRANSFORMATION_NAME, declaringType));
 	}
 
-	private String createChangeHistory(CtMethod<?> method) {
-		return String.format("Transformed junit4 assert to junit 5 assertion in %s", method.getSimpleName());
+	private MarkdownString createChangeHistory(CtMethod<?> method) {
+		return MarkdownString.fromMarkdown(
+			String.format("Transformed junit4 assert to junit 5 assertion in %s", method.getSimpleName()),
+			String.format("Transformed junit4 assert to junit 5 assertion in `%s`", method.getSimpleName()));
 	}
 
 	private void convertToJunit5(List<CtInvocation<?>> junit4Asserts) {

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/ExpectedExceptionRemoval.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/ExpectedExceptionRemoval.java
@@ -19,10 +19,14 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import xyz.keksdose.spoon.code_solver.history.Change;
 import xyz.keksdose.spoon.code_solver.history.ChangeListener;
+import xyz.keksdose.spoon.code_solver.history.MarkdownString;
 import xyz.keksdose.spoon.code_solver.transformations.ImportHelper;
 import xyz.keksdose.spoon.code_solver.transformations.TransformationProcessor;
 
 public class ExpectedExceptionRemoval extends TransformationProcessor<CtMethod<?>> {
+
+	private static final String CHANGE_TEXT_RAW = "Removed expected annotation from test method %s";
+	private static final String CHANGE_TEXT_MARKDOWN = "Removed expected annotation from test method `%s`";
 
 	public ExpectedExceptionRemoval(ChangeListener listener) {
 		super(listener);
@@ -44,7 +48,9 @@ public class ExpectedExceptionRemoval extends TransformationProcessor<CtMethod<?
 				ImportHelper.addImport("org.junit.jupiter.api.Assertions.assertThrows", true, compilationUnit);
 
 				setChanged(method.getParent(CtType.class),
-					new Change(String.format("Removed expected annotation from test method %s", method.getSimpleName()),
+					new Change(
+						MarkdownString.fromMarkdown(String.format(CHANGE_TEXT_RAW, method.getSimpleName()),
+							String.format(CHANGE_TEXT_MARKDOWN, method.getSimpleName())),
 						"ExpectedExceptionRemoval", method.getParent(CtType.class)));
 			}
 		}

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/Junit4AnnotationsTransformation.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/Junit4AnnotationsTransformation.java
@@ -11,6 +11,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import xyz.keksdose.spoon.code_solver.history.Change;
 import xyz.keksdose.spoon.code_solver.history.ChangeListener;
+import xyz.keksdose.spoon.code_solver.history.MarkdownString;
 import xyz.keksdose.spoon.code_solver.transformations.ImportHelper;
 import xyz.keksdose.spoon.code_solver.transformations.TransformationProcessor;
 
@@ -58,9 +59,13 @@ public class Junit4AnnotationsTransformation extends TransformationProcessor<CtM
 	}
 
 	private void notifyChangeListenerBeforeClass(CtMethod<?> method) {
-		setChanged(method.getParent(CtType.class), new Change(
-			String.format("Replaced @BeforeClass annotation with @BeforeAll from method %s", method.getSimpleName()),
-			PROCESSOR_NAME, method.getParent(CtType.class)));
+		CtType<?> declaringType = method.getParent(CtType.class);
+		String changeText = String.format("Replaced `@BeforeClass` annotation with `@BeforeAll` from method `%s`",
+			method.getSimpleName());
+		setChanged(declaringType, new Change(
+
+			MarkdownString.fromMarkdown(removeMarkdownBackticks(changeText), changeText), PROCESSOR_NAME,
+			declaringType));
 	}
 
 	private void refactorBefore(CtMethod<?> method) {
@@ -84,10 +89,12 @@ public class Junit4AnnotationsTransformation extends TransformationProcessor<CtM
 	}
 
 	private void notifyChangeListenerBefore(CtMethod<?> method) {
-		setChanged(method.getParent(CtType.class),
-			new Change(
-				String.format("Replaced @Before annotation with @BeforeEach from method %s", method.getSimpleName()),
-				PROCESSOR_NAME, method.getParent(CtType.class)));
+		CtType<?> declaringType = method.getParent(CtType.class);
+		String changeText = String.format("Replaced `@Before` annotation with @BeforeEach from method `%s`",
+			method.getSimpleName());
+		setChanged(declaringType,
+			new Change(MarkdownString.fromMarkdown(removeMarkdownBackticks(changeText), changeText), PROCESSOR_NAME,
+				declaringType));
 	}
 
 	private void refactorAfter(CtMethod<?> method) {
@@ -105,10 +112,13 @@ public class Junit4AnnotationsTransformation extends TransformationProcessor<CtM
 	}
 
 	private void notifyChangeListenerAfter(CtMethod<?> method) {
-		setChanged(method.getParent(CtType.class),
-			new Change(
-				String.format("Replaced @After annotation with @AfterEach from method %s", method.getSimpleName()),
-				PROCESSOR_NAME, method.getParent(CtType.class)));
+		CtType<?> declaringType = method.getParent(CtType.class);
+		String changeText = String.format("Replaced `@After` annotation with `@AfterEach` from method `%s`",
+			method.getSimpleName());
+
+		setChanged(declaringType,
+			new Change(MarkdownString.fromMarkdown(removeMarkdownBackticks(changeText), changeText), PROCESSOR_NAME,
+				declaringType));
 	}
 
 	private void adjustImportsAfter(CtMethod<?> method) {
@@ -131,10 +141,12 @@ public class Junit4AnnotationsTransformation extends TransformationProcessor<CtM
 	}
 
 	private void notifyChangeListenerAfterClass(CtMethod<?> method) {
-		setChanged(method.getParent(CtType.class),
-			new Change(
-				String.format("Replaced @AfterClass annotation with @AfterAll from method %s", method.getSimpleName()),
-				PROCESSOR_NAME, method.getParent(CtType.class)));
+		CtType<?> declaringType = method.getParent(CtType.class);
+		String changeText = String.format("Replaced `@AfterClass` annotation with `@AfterAll` from method `%s`",
+			method.getSimpleName());
+		setChanged(declaringType,
+			new Change(MarkdownString.fromMarkdown(removeMarkdownBackticks(changeText), changeText), PROCESSOR_NAME,
+				declaringType));
 	}
 
 	private void adjustImportsAfterClass(CtMethod<?> method) {
@@ -157,14 +169,20 @@ public class Junit4AnnotationsTransformation extends TransformationProcessor<CtM
 	}
 
 	private void notifyChangeListenerIgnore(CtMethod<?> method) {
-		setChanged(method.getParent(CtType.class),
-			new Change(
-				String.format("Replaced @Ignore annotation with @Disabled from method %s", method.getSimpleName()),
-				PROCESSOR_NAME, method.getParent(CtType.class)));
+		String changeText = String.format("Replaced `@Ignore` annotation with `@Disabled` from method `%s`",
+			method.getSimpleName());
+		CtType<?> declaringType = method.getParent(CtType.class);
+		setChanged(declaringType,
+			new Change(MarkdownString.fromMarkdown(removeMarkdownBackticks(changeText), changeText), PROCESSOR_NAME,
+				declaringType));
 	}
 
 	private void adjustImportsIgnore(CtMethod<?> method) {
 		ImportHelper.removeImport("org.junit.Ignore", false, method.getPosition().getCompilationUnit());
 		ImportHelper.addImport("org.junit.jupiter.api.Disabled", false, method.getPosition().getCompilationUnit());
+	}
+
+	private String removeMarkdownBackticks(String text) {
+		return text.replace("`", "");
 	}
 }

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/TestAnnotation.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/TestAnnotation.java
@@ -15,11 +15,15 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import xyz.keksdose.spoon.code_solver.history.Change;
 import xyz.keksdose.spoon.code_solver.history.ChangeListener;
+import xyz.keksdose.spoon.code_solver.history.MarkdownString;
 import xyz.keksdose.spoon.code_solver.transformations.ImportHelper;
 import xyz.keksdose.spoon.code_solver.transformations.TransformationProcessor;
 
 public class TestAnnotation extends TransformationProcessor<CtAnnotation<?>> {
 
+	private static final String CHANGE_TEXT_MARKDOWN = "Replaced junit 4 test annotation with junit 5 test annotation in `%s`";
+	private static final String CHANGE_TEXT_RAW = "Replaced junit 4 test annotation with junit 5 test annotation in %s";
+	private static final String RULE_NAME = "Junit4 @Test Annotation";
 	private static final String JUNIT4_TEST = "org.junit.Test";
 	private static final String JUNIT5_TEST = "org.junit.jupiter.api.Test";
 	private static final String JUNIT5_TIMEOUT = "org.junit.jupiter.api.Timeout";
@@ -47,8 +51,14 @@ public class TestAnnotation extends TransformationProcessor<CtAnnotation<?>> {
 	}
 
 	private void notifiyChangeListener(CtAnnotation<?> annotation, CtType<?> type) {
-		setChanged(type, new Change(String.format("Replaced junit 4 test annotation with junit 5 test annotation in %s",
-			((CtMethod<?>) annotation.getAnnotatedElement()).getSimpleName()), "Junit4 TestAnnotation", type));
+		setChanged(type,
+			new Change(MarkdownString.fromMarkdown(String.format(CHANGE_TEXT_RAW, getNameOfAnnotatedMethod(annotation)),
+				String.format(CHANGE_TEXT_MARKDOWN, ((CtMethod<?>) annotation.getAnnotatedElement()).getSimpleName())),
+				RULE_NAME, type));
+	}
+
+	private String getNameOfAnnotatedMethod(CtAnnotation<?> annotation) {
+		return ((CtMethod<?>) annotation.getAnnotatedElement()).getSimpleName();
 	}
 
 	private void refactorTimeoutAnnotation(CtAnnotation<?> annotation, CtElement element) {

--- a/code-transformation/src/main/resources/app.properties
+++ b/code-transformation/src/main/resources/app.properties
@@ -1,4 +1,6 @@
 git.author = 
 git.mail = 
 git.default_branch = 
-git.branch_prefix = 
+git.branch_prefix =
+changelog.markdown =
+changelog.markdown.file =


### PR DESCRIPTION
Because creating automatic pull requests is the long long term goal we need a better formatting in the issues.
For this markdown formatting for the changelog is important.
The following is way more readable then the old raw text: 
# Markdown Style Changelog
## The following has changed in the code:
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetCtRoleByName`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleGetSubRolesNotNull`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleSubRoleMatchesWithSuperRole`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleGetSubRole`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleGetSubRoleFailsOnOthers`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleGetSubRoleFailsOnNull`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `testGetCtRoleByName`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleGetSubRolesNotNull`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleSubRoleMatchesWithSuperRole`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleGetSubRole`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleGetSubRoleFailsOnOthers`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleGetSubRoleFailsOnNull`

# Raw Style
refactor(TestCtRole): 
 The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testGetCtRoleByName
Replaced junit 4 test annotation with junit 5 test annotation in testCtRoleGetSubRolesNotNull
Replaced junit 4 test annotation with junit 5 test annotation in testCtRoleSubRoleMatchesWithSuperRole
Replaced junit 4 test annotation with junit 5 test annotation in testCtRoleGetSubRole
Replaced junit 4 test annotation with junit 5 test annotation in testCtRoleGetSubRoleFailsOnOthers
Replaced junit 4 test annotation with junit 5 test annotation in testCtRoleGetSubRoleFailsOnNull
Transformed junit4 assert to junit 5 assertion in testGetCtRoleByName
Transformed junit4 assert to junit 5 assertion in testCtRoleGetSubRolesNotNull
Transformed junit4 assert to junit 5 assertion in testCtRoleSubRoleMatchesWithSuperRole
Transformed junit4 assert to junit 5 assertion in testCtRoleGetSubRole
Transformed junit4 assert to junit 5 assertion in testCtRoleGetSubRoleFailsOnOthers
Transformed junit4 assert to junit 5 assertion in testCtRoleGetSubRoleFailsOnNull


# Changes
- Add a new `MarkdownString` class, grouping String values with their markdown counterpart.
- Change `Change` to allow the new markdown variant
- Add two new config options to enable/disable the markdown changelog and set the filename 