### PR TITLE
feat: Remove protected modifiers from typemembers in final types

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-       java-version: 17
+       java-version: 11
        distribution: microsoft
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -44,8 +44,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -54,9 +54,8 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+       gradle build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/self/ProtectedMemberInFinalType.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/self/ProtectedMemberInFinalType.java
@@ -1,0 +1,55 @@
+
+package xyz.keksdose.spoon.code_solver.transformations.self;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import spoon.reflect.declaration.CtModifiable;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.declaration.ModifierKind;
+import xyz.keksdose.spoon.code_solver.history.Change;
+import xyz.keksdose.spoon.code_solver.history.ChangeListener;
+import xyz.keksdose.spoon.code_solver.history.MarkdownString;
+import xyz.keksdose.spoon.code_solver.transformations.BadSmell;
+import xyz.keksdose.spoon.code_solver.transformations.TransformationProcessor;
+
+public class ProtectedMemberInFinalType extends TransformationProcessor<CtType<?>> {
+
+	private static final BadSmell badSmell = new BadSmell() {
+
+		@Override
+		public MarkdownString getDescription() {
+			return MarkdownString.fromRaw(
+				"A protected member is used in a final class. Final classes are not allowed to be extended.");
+		}
+
+		@Override
+		public MarkdownString getName() {
+			return MarkdownString.fromRaw("Protected-In-Final-Class");
+		}
+	};
+
+	public ProtectedMemberInFinalType(ChangeListener listener) {
+		super(listener);
+	}
+
+	@Override
+	public void process(CtType<?> type) {
+		if (type.isFinal()) {
+			List<CtTypeMember> protectedMethods = type.getTypeMembers()
+					.stream()
+					.filter(CtModifiable::isProtected)
+					.collect(Collectors.toList());
+			for (CtTypeMember ctMethod : protectedMethods) {
+				ctMethod.removeModifier(ModifierKind.PROTECTED);
+				String message = "Removed protected modifier from " + ctMethod.getSimpleName() + " in "
+						+ type.getSimpleName();
+				String markdown = "Removed protected modifier from `" + ctMethod.getSimpleName() + "` in `"
+						+ type.getSimpleName() + "`";
+				setChanged(type, new Change(badSmell, MarkdownString.fromMarkdown(message, markdown), type));
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
A protected modifier is useless in a final type. We can simply remove it.