### PR TITLE
style: fix UnnecessaryToStringCall

### DIFF
--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/qodana/CollectionEmptyCheck.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/qodana/CollectionEmptyCheck.java
@@ -87,7 +87,7 @@ public class CollectionEmptyCheck extends TransformationProcessor<CtBinaryOperat
     private void notifyChangeListener(CtBinaryOperator<?> element, CtInvocation<Boolean> innvocation) {
         CtType<?> parent = element.getParent(CtType.class).getTopLevelType();
         String raw = "Replaced " + element + " with " + innvocation.toString();
-        String markdown = "Replaced `" + element + "` with `" + innvocation.toString() + "`";
+        String markdown = "Replaced `" + element + "` with `" + innvocation  + "`";
         setChanged(parent, new Change(COLLECTION_EMPTY_CHECK, MarkdownString.fromMarkdown(raw, markdown), parent));
     }
 

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/qodana/CollectionEmptyCheck.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/qodana/CollectionEmptyCheck.java
@@ -87,7 +87,7 @@ public class CollectionEmptyCheck extends TransformationProcessor<CtBinaryOperat
     private void notifyChangeListener(CtBinaryOperator<?> element, CtInvocation<Boolean> innvocation) {
         CtType<?> parent = element.getParent(CtType.class).getTopLevelType();
         String raw = "Replaced " + element + " with " + innvocation.toString();
-        String markdown = "Replaced `" + element + "` with `" + innvocation  + "`";
+        String markdown = "Replaced `" + element + "` with `" + innvocation + "`";
         setChanged(parent, new Change(COLLECTION_EMPTY_CHECK, MarkdownString.fromMarkdown(raw, markdown), parent));
     }
 

--- a/github-bot/src/main/java/io/github/martinwitt/laughing_train/App.java
+++ b/github-bot/src/main/java/io/github/martinwitt/laughing_train/App.java
@@ -171,7 +171,7 @@ public class App {
                     (v -> new QodanaRefactor(config.getActiveRules(), v, results));
             TransformationEngine transformationEngine = new TransformationEngine(List.of(function));
             transformationEngine.setChangeListener(changeListener);
-            System.out.println("refactorRepo: " + dir  + "/" + config.getSrcFolder());
+            System.out.println("refactorRepo: " + dir + "/" + config.getSrcFolder());
             transformationEngine.applyToGivenPath(dir + "/" + config.getSrcFolder());
         } catch (Exception e) {
             logger.atSevere().withCause(e).log("Failed to refactor repo");

--- a/github-bot/src/main/java/io/github/martinwitt/laughing_train/App.java
+++ b/github-bot/src/main/java/io/github/martinwitt/laughing_train/App.java
@@ -171,8 +171,8 @@ public class App {
                     (v -> new QodanaRefactor(config.getActiveRules(), v, results));
             TransformationEngine transformationEngine = new TransformationEngine(List.of(function));
             transformationEngine.setChangeListener(changeListener);
-            System.out.println("refactorRepo: " + dir.toString() + "/" + config.getSrcFolder());
-            transformationEngine.applyToGivenPath(dir.toString() + "/" + config.getSrcFolder());
+            System.out.println("refactorRepo: " + dir  + "/" + config.getSrcFolder());
+            transformationEngine.applyToGivenPath(dir + "/" + config.getSrcFolder());
         } catch (Exception e) {
             logger.atSevere().withCause(e).log("Failed to refactor repo");
         }


### PR DESCRIPTION
# Repairing Code Style Issues
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
# Repairing Code Style Issues
* UnnecessaryToStringCall (3)
