### PR TITLE
refactor: refactor bad smell UtilityClassWithoutPrivateConstructor

### DIFF
--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/github/CommitBuilder.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/github/CommitBuilder.java
@@ -23,8 +23,6 @@ public class CommitBuilder {
 
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-    public CommitBuilder() {}
-
     public static void refactorRepo(
             String path, String sourceFiles, String file, BiFunction<String, String, Changelog> transformation) {
         ConfigStore config = new ConfigStore();
@@ -103,5 +101,9 @@ public class CommitBuilder {
             }
         }
         return sb.toString();
+    }
+
+    private CommitBuilder() {
+        // UtilityClass
     }
 }

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/github/PullRequest.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/github/PullRequest.java
@@ -298,4 +298,8 @@ public class PullRequest {
         }
         return sb.toString();
     }
+
+    private PullRequest() {
+        // UtilityClass
+    }
 }

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/printing/PrinterCreation.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/printing/PrinterCreation.java
@@ -46,4 +46,8 @@ public class PrinterCreation {
         env.setPreserveLineNumbers(false);
         return () -> new ImportAwareSniperPrinter(env);
     }
+
+    private PrinterCreation() {
+        // UtilityClass
+    }
 }

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/JunitHelper.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/JunitHelper.java
@@ -138,4 +138,8 @@ public class JunitHelper {
     public static <T> CtTypeReference<T> getJunit5TestReference(Factory factory) {
         return factory.createReference("org.junit.jupiter.api.Test");
     }
+
+    private JunitHelper() {
+        // UtilityClass
+    }
 }


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UtilityClassWithoutPrivateConstructor
Utility classes should not have a public or default constructor.
<!-- fingerprint:-434429408 -->
<!-- fingerprint:-1701806060 -->
<!-- fingerprint:-1924936357 -->
<!-- fingerprint:1702902089 -->
# Repairing Code Style Issues
* UtilityClassWithoutPrivateConstructor (4)
