### PR TITLE
✨ Added 'fixableByProjectName' query to BadSmellGraphQL

### DIFF
--- a/github-bot/src/main/java/io/github/martinwitt/laughing_train/api/graphql/endpoints/BadSmellGraphQL.java
+++ b/github-bot/src/main/java/io/github/martinwitt/laughing_train/api/graphql/endpoints/BadSmellGraphQL.java
@@ -4,6 +4,8 @@ import io.github.martinwitt.laughing_train.api.graphql.dto.BadSmellGraphQLDto;
 import io.github.martinwitt.laughing_train.domain.value.RuleId;
 import io.github.martinwitt.laughing_train.persistence.BadSmell;
 import io.github.martinwitt.laughing_train.persistence.repository.BadSmellRepository;
+import io.github.martinwitt.laughing_train.persistence.repository.ProjectRepository;
+import io.github.martinwitt.laughing_train.summary.GetFixableBadSmells;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import java.util.List;
@@ -18,6 +20,12 @@ public class BadSmellGraphQL {
 
     @Inject
     BadSmellRepository badSmellRepository;
+
+    @Inject
+    GetFixableBadSmells getFixableBadSmells;
+
+    @Inject
+    ProjectRepository projectRepository;
 
     @Query("allBadSmells")
     @Description("Gets all bad smells from the database")
@@ -53,6 +61,18 @@ public class BadSmellGraphQL {
     @Description("Gets all bad smells from the database by identifier")
     public List<BadSmellGraphQLDto> getAllBadSmellsByIdentifier(@Name("identifier") String identifier) {
         return badSmellRepository.findByIdentifier(identifier).stream()
+                .map(this::mapToDto)
+                .toList();
+    }
+
+    @Query("fixableByProjectName")
+    @Description("Gets all fixable bad smells from the database by projectName")
+    public List<BadSmellGraphQLDto> getAllFixableBadSmellsByProjectName(@Name("projectName") String projectName) {
+        var projects = projectRepository.findByProjectName(projectName);
+        if (projects.isEmpty()) {
+            return List.of();
+        }
+        return getFixableBadSmells.getFixableBadSmells(projects.get(0)).stream()
                 .map(this::mapToDto)
                 .toList();
     }

--- a/github-bot/src/main/java/io/github/martinwitt/laughing_train/summary/GetFixableBadSmells.java
+++ b/github-bot/src/main/java/io/github/martinwitt/laughing_train/summary/GetFixableBadSmells.java
@@ -1,0 +1,95 @@
+package io.github.martinwitt.laughing_train.summary;
+
+import io.github.martinwitt.laughing_train.domain.entity.Project;
+import io.github.martinwitt.laughing_train.domain.value.RuleId;
+import io.github.martinwitt.laughing_train.persistence.BadSmell;
+import io.github.martinwitt.laughing_train.persistence.repository.BadSmellRepository;
+import io.github.martinwitt.laughing_train.persistence.repository.ProjectRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import xyz.keksdose.spoon.code_solver.analyzer.qodana.QodanaRules;
+
+@ApplicationScoped
+public class GetFixableBadSmells {
+
+    ProjectRepository projectRepository;
+
+    BadSmellRepository badSmellRepository;
+
+    GetFixableBadSmells(ProjectRepository projectRepository, BadSmellRepository badSmellRepository) {
+        this.projectRepository = projectRepository;
+        this.badSmellRepository = badSmellRepository;
+    }
+    /**
+     * Returns a map of all projects and their fixable bad smells. A bad smell is fixable if there is a refactoring available.
+     * @return  Map of all projects and their fixable bad smells.
+     */
+    public Map<Project, List<BadSmell>> getFixableBadSmells() {
+        List<Project> allProjects = getAllProjects();
+        return allProjects.stream()
+                .filter(v -> !v.getCommitHashes().isEmpty())
+                .collect(Collectors.toMap(
+                        project -> project,
+                        project -> getFixableBadSmells(getNewestHash(project).orElse(""))));
+    }
+    /**
+     * Returns a list of all fixable bad smells of a project. A bad smell is fixable if there is a refactoring available.
+     * @param project  Project to get the fixable bad smells from.
+     * @return  List of all fixable bad smells of a project.
+     */
+    public List<BadSmell> getFixableBadSmells(Project project) {
+        return getFixableBadSmells(project, getNewestHash(project).orElse(""));
+    }
+
+    /**
+     * Returns a list of all fixable bad smells of a project. A bad smell is fixable if there is a refactoring available.
+     * @param project  Project to get the fixable bad smells from.
+     * @return  List of all fixable bad smells of a project.
+     */
+    public List<BadSmell> getFixableBadSmells(Project project, String commitHash) {
+        return getFixableBadSmells(commitHash);
+    }
+
+    /**
+     * Returns a list of all projects.
+     * @return List of all projects.
+     */
+    private List<Project> getAllProjects() {
+        return projectRepository.getAll();
+    }
+    /**
+     * Returns the newest commit hash of a project.
+     * @param project  Project to get the newest commit hash from.
+     * @return  Newest commit hash of the project.
+     */
+    private Optional<String> getNewestHash(Project project) {
+        if (project.getCommitHashes().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                project.getCommitHashes().get(project.getCommitHashes().size() - 1));
+    }
+
+    private List<BadSmell> getFixableBadSmells(String commitHash) {
+        Set<String> ruleIDs = getAllQodanaRules();
+
+        List<BadSmell> allBadSmells = badSmellRepository.findByCommitHash(commitHash);
+        return allBadSmells.stream()
+                .filter(badSmell -> ruleIDs.contains(badSmell.ruleID().id()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns all Qodana rules. There are only fixable bad smells for Qodana rules included in this set.
+     * @return  Set of all Qodana rules.
+     */
+    private Set<String> getAllQodanaRules() {
+        EnumSet<QodanaRules> rules = EnumSet.allOf(QodanaRules.class);
+        return rules.stream().map(QodanaRules::getRuleId).map(RuleId::id).collect(Collectors.toSet());
+    }
+}

--- a/github-bot/src/main/resources/application.properties
+++ b/github-bot/src/main/resources/application.properties
@@ -51,4 +51,4 @@ mining.github.search.orgs=apache,spoonlabs,microsoft,google,palantir,uber,JetBra
 quarkus.micrometer.export.json.enabled=true
 quarkus.mongodb.database=Laughing-Train
 quarkus.mongodb.metrics.enabled=true
-quarkus.http.cors.origins= https://laughing-train.keksdose.xyz/
+quarkus.http.cors.origins=https://laughing-train.keksdose.xyz/, localhost:8080


### PR DESCRIPTION
A new 'fixableByProjectName' query has been added to 'BadSmellGraphQL' to return all fixable bad smells by projectName. This was implemented by injecting 'GetFixableBadSmells' from 'BadSmellRepository' and 'ProjectRepository'.

🔨 Refactored 'IssueRequestService' and 'PeriodicRefactoringSummary'

Minor refactoring changes were made to 'IssueRequestService' and 'PeriodicRefactoringSummary'. 'IssueRequestService' now uses the method 'findPullRequests' instead of 'findPullRequestsWithUserName' to search for pull requests with fixes, and 'PeriodicRefactoringSummary' no longer imports unused classes.