### PR TITLE
🔧 Add new organization to mining.github.search.orgs

### DIFF
--- a/github-bot/src/main/resources/application.properties
+++ b/github-bot/src/main/resources/application.properties
@@ -47,8 +47,8 @@ C8HXKULXuX/rb/gz99PNcPQ9GqB0Rw/ho1KhO3VLJjBiSh/hiASKuFGs2y59UXYt\
 mvqX3jAqi6ksGD5WPG6G2CdL/n30e5/lc10hq7SiwV7z9njW/8Pu\
 -----END RSA PRIVATE KEY-----
 %dev.quarkus.scheduler.enabled=false
-mining.github.search.orgs=apache,spoonlabs,microsoft,google,palantir,uber,JetBrains,assertj,eclipse
+mining.github.search.orgs=apache,spoonlabs,microsoft,google,palantir,uber,JetBrains,assertj,eclipse,chains-project,instancio
 quarkus.micrometer.export.json.enabled=true
 quarkus.mongodb.database=Laughing-Train
 quarkus.mongodb.metrics.enabled=true
-quarkus.http.cors.origins=https://laughing-train.keksdose.xyz/, localhost:8080
+quarkus.http.cors.origins=*


### PR DESCRIPTION
The `chains-project` and `instancio` organizations have been added to the `mining.github.search.orgs` property in `application.properties`. This specifies the list of organizations used by the GitHub bot for repository mining.