### PR TITLE
👷 Updated Qodana action and CodeQL in workflows

### DIFF
--- a/.github/workflows/qodana-cloud.yml
+++ b/.github/workflows/qodana-cloud.yml
@@ -1,0 +1,20 @@
+name: Code-Quality
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  qodana:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+        with:
+          fetch-depth: 0
+      - name: 'Qodana Scan'
+        uses: JetBrains/qodana-action@61b94e7e3a716dcb9e2030cfd79cd46149d56c26 # v2023.1.0
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+      - uses: github/codeql-action/upload-sarif@b2c19fb9a2a485599ccf4ed5d65527d94bc57226 # v2
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -11,13 +11,13 @@ jobs:
   qodana:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
         with:
           fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2022.3.4
+        uses: JetBrains/qodana-action@61b94e7e3a716dcb9e2030cfd79cd46149d56c26 # v2023.1.0
         with:
-          args: --fail-threshold, 0
-      - uses: github/codeql-action/upload-sarif@v2
+          args: "--fail-threshold,0"
+      - uses: github/codeql-action/upload-sarif@b2c19fb9a2a485599ccf4ed5d65527d94bc57226 # v2
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/analyzer/qodana/QodanaAnalyzer.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/analyzer/qodana/QodanaAnalyzer.java
@@ -272,11 +272,9 @@ public class QodanaAnalyzer {
     public static class Builder {
 
         private String resultFolder = "laughing-cache";
-        private String qodanaImageName = "jetbrains/qodana-jvm-community";
+        private String qodanaImageName = "jetbrains/qodana-jvm:2023.1-eap";
         private String resultPathString = resultFolder + "/qodana.sarif.json";
         private String sourceFileRoot = "./src/main/java";
-        private Optional<String> cacheFolder = Optional.of("data/cache");
-        private String subFolder;
 
         public Builder withResultFolder(String resultFolder) {
             this.resultFolder = resultFolder;
@@ -298,12 +296,6 @@ public class QodanaAnalyzer {
 
         public Builder withSourceFileRoot(String sourceFileRoot) {
             this.sourceFileRoot = sourceFileRoot;
-            return this;
-        }
-
-        public Builder withCacheVolume(String volumeName, String subFolder) {
-            this.cacheFolder = Optional.of(volumeName);
-            this.subFolder = subFolder;
             return this;
         }
 

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/analyzer/qodana/QodanaRefactor.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/analyzer/qodana/QodanaRefactor.java
@@ -26,7 +26,7 @@ import xyz.keksdose.spoon.code_solver.history.ChangeListener;
 import xyz.keksdose.spoon.code_solver.transformations.TransformationProcessor;
 
 /**
- * This aggreates all qodana refactorings and wraps them in a single processor.
+ * This aggregates all qodana refactorings and wraps them in a single processor.
  * Use {@link run(Path, ChangeListener)} to analyse the source code.
  * <b> Note: </b> This requires a running docker host and can take some minutes.
  */

--- a/code-transformation/src/main/resources/qodana.yml
+++ b/code-transformation/src/main/resources/qodana.yml
@@ -1,68 +1,41 @@
 profile:
   name: qodana.recommended
 version: "1.0"
-linter: jetbrains/qodana-jvm-community:2022.3
-include:
-  - name: Anonymous2MethodRef
-  - name: AnonymousHasLambdaAlternative
-  - name: ArrayEquality
-  - name: AssignmentToCatchBlockParameter
-  - name: AssignmentToLambdaParameter
-  - name: AssignmentToMethodParameter
-  - name: BoundedWildcard
-  - name: CallToStringConcatCanBeReplacedByOperator
-  - name: CodeBlock2Expr
-  - name: ConstantMathCall
-  - name: Convert2Lambda
-  - name: Convert2MethodRef
-  - name: DoubleBraceInitialization
-  - name: DynamicRegexReplaceableByCompiledPattern
-  - name: EmptyMethod
-  - name: EqualsAndHashcode
-  - name: GroovyUnnecessaryContinue
-  - name: GroovyUnnecessaryReturn
-  - name: GroovyUnusedAssignment
-  - name: Java8ListReplaceAll
-  - name: Java8MapApi
-  - name: JavaLangImport
-  - name: JoinDeclarationAndAssignmentJava
-  - name: KeySetIterationMayUseEntrySet
-  - name: MissortedModifiers
-  - name: NestedAssignment
-  - name: NonFinalFieldOfException
-  - name: NonProtectedConstructorInAbstractClass
-  - name: NonSerializableFieldInSerializableClass
-  - name: NonShortCircuitBoolean
-  - name: NonStrictComparisonCanBeEquality
-  - name: OptionalContainsCollection
-  - name: ProtectedMemberInFinalClass
-  - name: RandomDoubleForRandomInteger
-  - name: RedundantFieldInitialization
-  - name: RedundantImplements
-  - name: RedundantMethodOverride
-  - name: RedundantSuppression
-  - name: Reformat
-  - name: ReturnNull
-  - name: SamePackageImport
-  - name: SimplifyBooleanWithConstants
-  - name: SizeReplaceableByIsEmpty
-  - name: StaticCallOnSubclass
-  - name: StaticPseudoFunctionalStyleMethod
-  - name: StringEquality
-  - name: ToArrayCallWithZeroLengthArrayArgument
-  - name: UnnecessaryBoxing
-  - name: UnnecessaryCallToStringValueOf
-  - name: UnnecessaryFullyQualifiedName
-  - name: UnnecessaryLocalVariable
-  - name: UnnecessaryModifier
-  - name: UnnecessarySuperQualifier
-  - name: UnnecessaryToStringCall
-  - name: UnnecessaryUnboxing
-  - name: UNUSED_IMPORT
-  - name: ZeroLengthArrayInitialization
-  - name: WhileCanBeForeach
-  - name: UtilityClassWithoutPrivateConstructor
-  - name: UtilityClassWithPublicConstructor
+linter: jetbrains/qodana-jvm:2023.1-eap
+groups:
+  - groupId: IncludedPaths
+    groups:
+          - "category:Java"
+          - "GLOBAL"
+  - groupId: ExcludedInspections # list of inspections disabled by specific reason
+    inspections:
+      - "!IncludedPaths"
+      - Annotator # substituted by JavaAnnotator in sanity
+      - JavaAnnotator # works in "sanity" inspections
+      - SyntaxError # should work on sanity level
+      - Since15 #Detects wrong language level. Should work on sanity.
+      - JavadocBlankLines # Questionable. Spam on mockito, RxJava and other projects.
+      - UseOfClone
+      - UnstableApiUsage
+inspections:
+  - group: ExcludedInspections
+    enabled: false
+  - group: IncludedPaths
+    ignore:
+      - "vendor/**"
+      - "build/**"
+      - "buildSrc/**"
+      - "builds/**"
+      - "dist/**"
+      - "tests/**"
+      - "tools/**"
+      - "vendor/**"
+      - "**.test.ts"
+      - "scope#$gitignore" # $gitignore scope available only in qodana execution
+      - "scope#test:*..*"
+      - "scope#file:buildSrc/*"
+  - inspection: JavadocReference
+    severity: WARNING # It has default ERROR severity. It's understandable for unresolved references in javadocs for editor but not on CI.
 exclude:
   - name: UseOfClone
   - name: JavaAnnotator

--- a/qodana.yml
+++ b/qodana.yml
@@ -1,66 +1,42 @@
 profile:
   name: qodana.recommended
 version: "1.0"
-linter: jetbrains/qodana-jvm-community:2022.3
-include:
-  - name: Anonymous2MethodRef
-  - name: AnonymousHasLambdaAlternative
-  - name: ArrayEquality
-  - name: AssignmentToCatchBlockParameter
-  - name: AssignmentToLambdaParameter
-  - name: AssignmentToMethodParameter
-  - name: BoundedWildcard
-  - name: CallToStringConcatCanBeReplacedByOperator
-  - name: CodeBlock2Expr
-  - name: ConstantMathCall
-  - name: Convert2Lambda
-  - name: Convert2MethodRef
-  - name: DoubleBraceInitialization
-  - name: DynamicRegexReplaceableByCompiledPattern
-  - name: EmptyMethod
-  - name: EqualsAndHashcode
-  - name: GroovyUnnecessaryContinue
-  - name: GroovyUnnecessaryReturn
-  - name: GroovyUnusedAssignment
-  - name: Java8ListReplaceAll
-  - name: Java8MapApi
-  - name: JavaLangImport
-  - name: JoinDeclarationAndAssignmentJava
-  - name: KeySetIterationMayUseEntrySet
-  - name: MissortedModifiers
-  - name: NestedAssignment
-  - name: NonFinalFieldOfException
-  - name: NonProtectedConstructorInAbstractClass
-  - name: NonSerializableFieldInSerializableClass
-  - name: NonShortCircuitBoolean
-  - name: NonStrictComparisonCanBeEquality
-  - name: OptionalContainsCollection
-  - name: ProtectedMemberInFinalClass
-  - name: RandomDoubleForRandomInteger
-  - name: RedundantFieldInitialization
-  - name: RedundantImplements
-  - name: RedundantMethodOverride
-  - name: RedundantSuppression
-  - name: Reformat
-  - name: ReturnNull
-  - name: SamePackageImport
-  - name: SimplifyBooleanWithConstants
-  - name: SizeReplaceableByIsEmpty
-  - name: StaticPseudoFunctionalStyleMethod
-  - name: StringEquality
-  - name: ToArrayCallWithZeroLengthArrayArgument
-  - name: UnnecessaryBoxing
-  - name: UnnecessaryCallToStringValueOf
-  - name: UnnecessaryFullyQualifiedName
-  - name: UnnecessaryLocalVariable
-  - name: UnnecessaryModifier
-  - name: UnnecessarySuperQualifier
-  - name: UnnecessaryToStringCall
-  - name: UnnecessaryUnboxing
-  - name: UNUSED_IMPORT
-  - name: ZeroLengthArrayInitialization
-  - name: WhileCanBeForeach
+linter: jetbrains/qodana-jvm:2023.1-eap
+groups:
+  - groupId: IncludedPaths
+    groups:
+          - "category:Java"
+          - "GLOBAL"
+  - groupId: ExcludedInspections # list of inspections disabled by specific reason
+    inspections:
+      - "!IncludedPaths"
+      - Annotator # substituted by JavaAnnotator in sanity
+      - JavaAnnotator # works in "sanity" inspections
+      - SyntaxError # should work on sanity level
+      - Since15 #Detects wrong language level. Should work on sanity.
+      - JavadocBlankLines # Questionable. Spam on mockito, RxJava and other projects.
+      - UseOfClone
+      - UnstableApiUsage
+inspections:
+  - group: ExcludedInspections
+    enabled: false
+  - group: IncludedPaths
+    ignore:
+      - "vendor/**"
+      - "build/**"
+      - "buildSrc/**"
+      - "builds/**"
+      - "dist/**"
+      - "tests/**"
+      - "tools/**"
+      - "vendor/**"
+      - "**.test.ts"
+      - "scope#$gitignore" # $gitignore scope available only in qodana execution
+      - "scope#test:*..*"
+      - "scope#file:buildSrc/*"
+  - inspection: JavadocReference
+    severity: WARNING # It has default ERROR severity. It's understandable for unresolved references in javadocs for editor but not on CI.
 exclude:
   - name: UseOfClone
   - name: JavaAnnotator
-  - name: StaticCallOnSubclass
+  - name: MethodMayBeStatic


### PR DESCRIPTION
Updated Qodana and CodeQL to their latest versions. Qodana scan now fails when issues are encountered with severity greater than 0. Additionally, outdated and removed Qodana rules were removed from the Qodana profile YAML files. Finally, removed an optional `cacheVolume` field in `QodanaAnalyzer`.