### PR TITLE
refactor: refactor bad smell InnerClassMayBeStatic

### DIFF
--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/analyzer/qodana/QodanaAnalyzer.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/analyzer/qodana/QodanaAnalyzer.java
@@ -242,7 +242,7 @@ public class QodanaAnalyzer {
         return results;
     }
 
-    private final class ResultCallbackImplementation implements ResultCallback<Frame> {
+    private static final class ResultCallbackImplementation implements ResultCallback<Frame> {
         private final StringBuilder sb;
 
         private ResultCallbackImplementation(StringBuilder sb) {


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## InnerClassMayBeStatic
Inner classes that do not reference their enclosing instances can be made static.
This prevents a common cause of memory leaks and uses less memory per instance of the class.

<!-- fingerprint:Qodana-laughing-train-InnerClassMayBeStatic-e2a4a45fef8e762da3d045589a54ef73ec740f84-sl:245-el:0-sc:25-ec:0-co:11022-cl:28 -->
# Repairing Code Style Issues
* InnerClassMayBeStatic (1)
