### PR TITLE
RenameSuggestion

### DIFF
--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/simplification/AssertNotNullTransformation.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/simplification/AssertNotNullTransformation.java
@@ -66,13 +66,13 @@ public class AssertNotNullTransformation extends TransformationProcessor<CtInvoc
         CtType<?> parent = element.getParent(CtType.class);
         CtCompilationUnit compilationUnit = element.getPosition().getCompilationUnit();
 
-        if (parent != null && !hasJunit5AsserTrueLeft(parent)) {
+        if (parent != null && !hasJunit5AssertTrueLeft(parent)) {
             ImportHelper.removeImport("org.junit.jupiter.api.Assertions.assertTrue", true, compilationUnit);
         }
         ImportHelper.addImport("org.junit.jupiter.api.Assertions.assertNotNull", true, compilationUnit);
     }
 
-    private boolean hasJunit5AsserTrueLeft(CtType<?> parent) {
+    private boolean hasJunit5AssertTrueLeft(CtType<?> parent) {
         return parent.getElements(new TypeFilter<>(CtInvocation.class)).stream()
                 .filter(v -> v.getExecutable() != null)
                 .anyMatch(v -> JunitHelper.isJunit5AssertTrue(v.getExecutable()));

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/simplification/AssertNullTransformation.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/simplification/AssertNullTransformation.java
@@ -66,13 +66,13 @@ public class AssertNullTransformation extends TransformationProcessor<CtInvocati
         CtType<?> parent = element.getParent(CtType.class);
         CtCompilationUnit compilationUnit = element.getPosition().getCompilationUnit();
 
-        if (parent != null && !hasJunit5AsserTrueLeft(parent)) {
+        if (parent != null && !hasJunit5AssertTrueLeft(parent)) {
             ImportHelper.removeImport("org.junit.jupiter.api.Assertions.assertTrue", true, compilationUnit);
         }
         ImportHelper.addImport("org.junit.jupiter.api.Assertions.assertNull", true, compilationUnit);
     }
 
-    private boolean hasJunit5AsserTrueLeft(CtType<?> parent) {
+    private boolean hasJunit5AssertTrueLeft(CtType<?> parent) {
         return parent.getElements(new TypeFilter<>(CtInvocation.class)).stream()
                 .filter(v -> v.getExecutable() != null)
                 .anyMatch(v -> JunitHelper.isJunit5AssertTrue(v.getExecutable()));

--- a/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/simplification/AssertTrueEqualsCheck.java
+++ b/code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/simplification/AssertTrueEqualsCheck.java
@@ -50,13 +50,13 @@ public class AssertTrueEqualsCheck extends TransformationProcessor<CtInvocation<
         CtType<?> parent = element.getParent(CtType.class);
         CtCompilationUnit compilationUnit = element.getPosition().getCompilationUnit();
 
-        if (parent != null && !hasJunit5AsserTrueLeft(parent)) {
+        if (parent != null && !hasJunit5AssertTrueLeft(parent)) {
             ImportHelper.removeImport("org.junit.jupiter.api.Assertions.assertTrue", true, compilationUnit);
         }
         ImportHelper.addImport("org.junit.jupiter.api.Assertions.assertEquals", true, compilationUnit);
     }
 
-    private boolean hasJunit5AsserTrueLeft(CtType<?> parent) {
+    private boolean hasJunit5AssertTrueLeft(CtType<?> parent) {
         return parent.getElements(new TypeFilter<>(CtInvocation.class)).stream()
                 .filter(v -> v.getExecutable() != null)
                 .anyMatch(v -> JunitHelper.isJunit5AssertTrue(v.getExecutable()));


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find a non-descriptive method name in your repository:

```java
/* Non-descriptive Method Name in code-transformation/src/main/java/xyz/keksdose/spoon/code_solver/transformations/junit/simplification/AssertNotNullTransformation.java */
    private boolean hasJunit5AsserTrueLeft(CtType<?> parent) {
        return parent.getElements(new TypeFilter<>(CtInvocation.class)).stream()
                .filter(v -> v.getExecutable() != null)
                .anyMatch(v -> JunitHelper.isJunit5AssertTrue(v.getExecutable()));
    }

```
We consider "hasJunit5AsserTrueLeft" as non-descriptive because it contains a typo, i.e., "Asser" should be "Assert".  We have corrected it (including all the occurrence in other file) and submitted a pull request.

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.