### PR TITLE
fix: bi-directional relationship between ProjectDao and GitHubCommitDao

### DIFF
--- a/github-bot/src/main/java/io/github/martinwitt/laughing_train/persistence/dao/GitHubCommitDao.java
+++ b/github-bot/src/main/java/io/github/martinwitt/laughing_train/persistence/dao/GitHubCommitDao.java
@@ -2,14 +2,24 @@ package io.github.martinwitt.laughing_train.persistence.dao;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class GitHubCommitDao extends PanacheEntity {
 
+  @ManyToOne private ProjectDao projectDao;
   private String commitHash;
 
   public GitHubCommitDao() {
     // for JPA
+  }
+
+  public ProjectDao getProjectDao() {
+    return projectDao;
+  }
+
+  public void setProjectDao(ProjectDao projectDao) {
+    this.projectDao = projectDao;
   }
 
   /**

--- a/github-bot/src/main/java/io/github/martinwitt/laughing_train/persistence/dao/ProjectDao.java
+++ b/github-bot/src/main/java/io/github/martinwitt/laughing_train/persistence/dao/ProjectDao.java
@@ -60,6 +60,7 @@ public class ProjectDao extends PanacheEntity {
    * @param commits the commits to set
    */
   public void setCommits(List<GitHubCommitDao> commits) {
+    commits.forEach(it -> it.setProjectDao(this));
     this.commits = commits;
   }
 }


### PR DESCRIPTION
A bi-directional relationship has been set up between the ProjectDao and GitHubCommitDao classes in the persistence/dao package. The changes ensure that each GitHubCommitDao entity is associated with a specific ProjectDao and vice versa.