### PR TITLE
fix: Add JetBrains annotations dependency in GitHub Bot

### DIFF
--- a/github-bot/build.gradle
+++ b/github-bot/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation("io.quarkus:quarkus-hibernate-orm-panache")
 	implementation("io.quarkus:quarkus-jdbc-mariadb")
 	implementation("io.quarkus:quarkus-opentelemetry")
+	implementation 'org.jetbrains:annotations:24.1.0'
 
 	implementation project(":commons")
 	implementation project(path: ':spoon-analyzer')


### PR DESCRIPTION
JetBrains annotations dependency 'org.jetbrains:annotations:24.1.0' was added to the project's build.gradle file. This would enable use of JetBrains' advanced code inspection and manipulation features.